### PR TITLE
Command Line Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Collection of scripts that shovel data into graphite.  Throw into cron and go!
 Requires the snmp gem, additional counters can be added with an easy edit
 
 ```
-$ ./ifstats_to_graphite.rb 
+$ ./ifstats_to_graphite.rb
 Usage: ./ifstats_to_graphite.rb -c COMMUNITY [-h HOST | -f FILE] [options]
     -c, --community COMMUNITY        SNMP community string for device(s)
     -h, --host HOST                  hostname or IP address of device to poll
@@ -42,7 +42,7 @@ ifstats.myswitch_foo_com.TenGigabitEthernet1-1.OutBroadcastPkts 701814 144328135
 Additional files and counters of interest can be added with a simple tweak to the file.  Run this with a very short polling interval to catch some microbursts in action.
 
 ```
-$ ./procnet_to_graphite.rb 
+$ ./procnet_to_graphite.rb
 Usage: ./procnet_to_graphite.rb [-g HOST | -d] [options]
     -g, --graphite-host HOST         hostname or IP address of graphite host to send metrics to
     -l, --graphite-port PORT         graphite listening port (defaults to 2003)

--- a/ifstats_to_graphite.rb
+++ b/ifstats_to_graphite.rb
@@ -35,8 +35,8 @@ $varbinds = 0
 OptionParser.new do |o|
   o.banner = "Usage: #{$0} -c COMMUNITY [-h HOST | -f FILE] [options]"
   o.on('-c', '--community COMMUNITY', 'SNMP community string for device(s)') { |b| $community = b }
-  o.on('-h', '--host HOST', 'hostname or IP address of device to poll')  { |b| abort "Error: -d and -f cannot be specified together." unless $hosts.empty?; $hosts << b }
-  o.on('-f', '--file FILE', 'file containing a list of devices to poll') { |b| abort "Error: -d and -f cannot be specified together." unless $hosts.empty? ; handle_file(b) }
+  o.on('-h', '--host HOST', 'hostname or IP address of device to poll')  { |b| abort "Error: -h and -f cannot be specified together." unless $hosts.empty?; $hosts << b }
+  o.on('-f', '--file FILE', 'file containing a list of devices to poll') { |b| abort "Error: -h and -f cannot be specified together." unless $hosts.empty? ; handle_file(b) }
   o.on('-g', '--graphite-host HOST', 'hostname or IP address of graphite host to send metrics to') { |b| $graphite_host = b }
   o.on('-l', '--graphite-port PORT', "graphite listening port (defaults to #{$graphite_port})") { |b| $graphite_port = b.to_i }
   o.on('-x', '--graphite-prefix PREFIX', "prefix for metric names (defaults to #{$graphite_prefix})") { |b| $graphite_prefix = b }

--- a/ipifstats_to_graphite.rb
+++ b/ipifstats_to_graphite.rb
@@ -32,8 +32,8 @@ $varbinds = 0
 OptionParser.new do |o|
   o.banner = "Usage: #{$0} -c COMMUNITY [-h HOST | -f FILE] [options]"
   o.on('-c', '--community COMMUNITY', 'SNMP community string for device(s)') { |b| $community = b }
-  o.on('-h', '--host HOST', 'hostname or IP address of device to poll')  { |b| abort "Error: -d and -f cannot be specified together." unless $hosts.empty?; $hosts << b }
-  o.on('-f', '--file FILE', 'file containing a list of devices to poll') { |b| abort "Error: -d and -f cannot be specified together." unless $hosts.empty? ; handle_file(b) }
+  o.on('-h', '--host HOST', 'hostname or IP address of device to poll')  { |b| abort "Error: -h and -f cannot be specified together." unless $hosts.empty?; $hosts << b }
+  o.on('-f', '--file FILE', 'file containing a list of devices to poll') { |b| abort "Error: -h and -f cannot be specified together." unless $hosts.empty? ; handle_file(b) }
   o.on('-g', '--graphite-host HOST', 'hostname or IP address of graphite host to send metrics to') { |b| $graphite_host = b }
   o.on('-l', '--graphite-port PORT', "graphite listening port (defaults to #{$graphite_port})") { |b| $graphite_port = b.to_i }
   o.on('-x', '--graphite-prefix PREFIX', "prefix for metric names (defaults to #{$graphite_prefix})") { |b| $graphite_prefix = b }

--- a/procnet_to_graphite.rb
+++ b/procnet_to_graphite.rb
@@ -13,8 +13,8 @@ $graphite_prefix = 'netstat'
 $debug = false
 
 files = [ '/proc/net/snmp', '/proc/net/netstat' ]
-counters = [ 'Tcp.RetransSegs', 'Tcp.AttemptFails', 'Tcp.EstabResets', 'Tcp.OutRsts', 'Tcp.InRsts', 
-             'Tcp.InErrs', 'Tcp.InCsumErrors', 'Tcp.CurrEstab', 'Tcp.ActiveOpens', 'Tcp.PassiveOpens', 
+counters = [ 'Tcp.RetransSegs', 'Tcp.AttemptFails', 'Tcp.EstabResets', 'Tcp.OutRsts', 'Tcp.InRsts',
+             'Tcp.InErrs', 'Tcp.InCsumErrors', 'Tcp.CurrEstab', 'Tcp.ActiveOpens', 'Tcp.PassiveOpens',
              'TcpExt.TCPTimeWaitOverflow', 'TcpExt.RcvPruned', 'TcpExt.TCPBacklogDrop',
              'TcpExt.PruneCalled', 'TcpExt.ListenOverflows', 'TcpExt.ListenDrops', 'TcpExt.TCPTimeouts',
              'TcpExt.TCPMemoryPressures', 'TcpExt.TCPReqQFullDoCookies', 'TcpExt.TCPReqQFullDrop',

--- a/procnet_to_graphite.rb
+++ b/procnet_to_graphite.rb
@@ -23,7 +23,7 @@ counters = [ 'Tcp.RetransSegs', 'Tcp.AttemptFails', 'Tcp.EstabResets', 'Tcp.OutR
 ARGV << '-h' if ARGV.empty?
 
 OptionParser.new do |o|
-  o.banner = "Usage: #{$0} [-g HOST | -t] [options]"
+  o.banner = "Usage: #{$0} [-g HOST] [options]"
   o.on('-g', '--graphite-host HOST', 'hostname or IP address of graphite host to send metrics to') { |b| $graphite_host = b }
   o.on('-l', '--graphite-port PORT', "graphite listening port (defaults to #{$graphite_port})") { |b| $graphite_port = b.to_i }
   o.on('-x', '--graphite-prefix PREFIX', "prefix for metric names (defaults to #{$graphite_prefix})") { |b| $graphite_prefix = b }


### PR DESCRIPTION
Command Line options list "-d" instead of "-h" for possible conflicts with "-f" ... fixed.
Removes superfluous "-t" option in procnet_to_graphite.
Also removes trailing whitespace from some files.